### PR TITLE
Distinguish Resources Paths in Airlines App, by username and id

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.payara-p1</version>
+        <version>3.1.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.eclipse.microprofile.openapi</groupId>
     <artifactId>microprofile-openapi-parent</artifactId>
-    <version>3.1.payara-p1</version>
+    <version>3.1.1.payara-p1</version>
     <packaging>pom</packaging>
     <name>MicroProfile OpenAPI</name>
     <description>Eclipse MicroProfile OpenAPI</description>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <groupId>org.eclipse.microprofile.openapi</groupId>
     <artifactId>microprofile-openapi-parent</artifactId>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.1.payara-p1</version>
     <packaging>pom</packaging>
     <name>MicroProfile OpenAPI</name>
     <description>Eclipse MicroProfile OpenAPI</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-spec</artifactId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.payara-p1</version>
+        <version>3.1.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-spec</artifactId>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-spi</artifactId>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.payara-p1</version>
+        <version>3.1.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-spi</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.1.payara-p1</version>
+        <version>3.1.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-tck</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-parent</artifactId>
-        <version>3.2-SNAPSHOT</version>
+        <version>3.1.payara-p1</version>
     </parent>
 
     <artifactId>microprofile-openapi-tck</artifactId>

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/apps/airlines/resources/UserResource.java
@@ -178,7 +178,7 @@ public class UserResource {
         return Response.ok().entity("").build();
     }
 
-    @Path("/{username}")
+    @Path("/username/{username}")
     @PUT
     @RequestBody(name = "user", description = "Record of a new user to be created in the system.",
                  content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class),
@@ -207,7 +207,7 @@ public class UserResource {
     }
 
     @PATCH
-    @Path("/{username}")
+    @Path("/username/{username}")
     @APIResponse(responseCode = "200", description = "Password was changed successfully")
     @Operation(summary = "Change user password", description = "This changes the password for the logged in user.",
                operationId = "changePassword")
@@ -229,7 +229,7 @@ public class UserResource {
     }
 
     @DELETE
-    @Path("/{username}")
+    @Path("/username/{username}")
     @Tag(ref = "user")
     @APIResponse(responseCode = "200", description = "User deleted successfully")
     @APIResponse(responseCode = "400", description = "Invalid username supplied")
@@ -248,7 +248,7 @@ public class UserResource {
     }
 
     @GET
-    @Path("/{username}")
+    @Path("/username/{username}")
     @Tag(ref = "user")
     @APIResponses(value = {
             @APIResponse(responseCode = "200", description = "Successfully retrieved user by user name.",
@@ -270,7 +270,7 @@ public class UserResource {
     }
 
     @GET
-    @Path("/{id}")
+    @Path("/id/{id}")
     @Tag(ref = "user")
     @APIResponse(responseCode = "200", description = "Successfully retrieved user by id.",
                  content = @Content(schema = @Schema(implementation = User.class)), links = {

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/AirlinesAppTest.java
@@ -255,19 +255,21 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user/createWithList'.post.summary", equalTo("Creates list of users with given input list"));
         vr.body("paths.'/user/createWithList'.post.operationId", equalTo("createUsersFromList"));
 
-        vr.body("paths.'/user/{username}'.put.summary", equalTo("Update user"));
-        vr.body("paths.'/user/{username}'.put.description", equalTo("This can only be done by the logged in user."));
-        vr.body("paths.'/user/{username}'.put.operationId", equalTo("updateUser"));
+        vr.body("paths.'/user/username/{username}'.put.summary", equalTo("Update user"));
+        vr.body("paths.'/user/username/{username}'.put.description",
+                equalTo("This can only be done by the logged in user."));
+        vr.body("paths.'/user/username/{username}'.put.operationId", equalTo("updateUser"));
 
-        vr.body("paths.'/user/{username}'.delete.summary", equalTo("Delete user"));
-        vr.body("paths.'/user/{username}'.delete.description", equalTo("This can only be done by the logged in user."));
-        vr.body("paths.'/user/{username}'.delete.operationId", equalTo("deleteUser"));
+        vr.body("paths.'/user/username/{username}'.delete.summary", equalTo("Delete user"));
+        vr.body("paths.'/user/username/{username}'.delete.description",
+                equalTo("This can only be done by the logged in user."));
+        vr.body("paths.'/user/username/{username}'.delete.operationId", equalTo("deleteUser"));
 
-        vr.body("paths.'/user/{username}'.get.summary", equalTo("Get user by user name"));
-        vr.body("paths.'/user/{username}'.get.operationId", equalTo("getUserByName"));
+        vr.body("paths.'/user/username/{username}'.get.summary", equalTo("Get user by user name"));
+        vr.body("paths.'/user/username/{username}'.get.operationId", equalTo("getUserByName"));
 
-        vr.body("paths.'/user/{id}'.get.summary", equalTo("Get user by id"));
-        vr.body("paths.'/user/{id}'.get.operationId", equalTo("getUserById"));
+        vr.body("paths.'/user/id/{id}'.get.summary", equalTo("Get user by id"));
+        vr.body("paths.'/user/id/{id}'.get.operationId", equalTo("getUserById"));
 
         vr.body("paths.'/user/login'.get.summary", equalTo("Logs user into the system"));
         vr.body("paths.'/user/login'.get.operationId", equalTo("logInUser"));
@@ -275,11 +277,11 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user/logout'.get.summary", equalTo("Logs out current logged in user session"));
         vr.body("paths.'/user/logout'.get.operationId", equalTo("logOutUser"));
 
-        vr.body("paths.'/user/{username}'.patch.summary", equalTo("Change user password"));
-        vr.body("paths.'/user/{username}'.patch.description",
+        vr.body("paths.'/user/username/{username}'.patch.summary", equalTo("Change user password"));
+        vr.body("paths.'/user/username/{username}'.patch.description",
                 equalTo("This changes the password for the logged in user."));
-        vr.body("paths.'/user/{username}'.patch.operationId", equalTo("changePassword"));
-        vr.body("paths.'/user/{username}'.patch.parameters", hasSize(3));
+        vr.body("paths.'/user/username/{username}'.patch.operationId", equalTo("changePassword"));
+        vr.body("paths.'/user/username/{username}'.patch.parameters", hasSize(3));
 
         // Operation with hidden schemas
         vr.body("paths.'/user/special'.post.requestBody.content.'application/json'.schema", is(nullValue()));
@@ -298,16 +300,18 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/bookings'.post.responses.'201'.description", equalTo("Booking created"));
 
         // @APIResponse at class level overridden at method level
-        vr.body("paths.'/user/{username}'.delete.responses", aMapWithSize(3));
-        vr.body("paths.'/user/{username}'.delete.responses.'200'.description", equalTo("User deleted successfully"));
-        vr.body("paths.'/user/{username}'.delete.responses.'400'.description", equalTo("Invalid username supplied"));
-        vr.body("paths.'/user/{username}'.delete.responses.'404'.description", equalTo("User not found"));
+        vr.body("paths.'/user/username/{username}'.delete.responses", aMapWithSize(3));
+        vr.body("paths.'/user/username/{username}'.delete.responses.'200'.description",
+                equalTo("User deleted successfully"));
+        vr.body("paths.'/user/username/{username}'.delete.responses.'400'.description",
+                equalTo("Invalid username supplied"));
+        vr.body("paths.'/user/username/{username}'.delete.responses.'404'.description", equalTo("User not found"));
 
         // @APIResponse at class level combined with method level
-        vr.body("paths.'/user/{username}'.patch.responses", aMapWithSize(2));
-        vr.body("paths.'/user/{username}'.patch.responses.'200'.description",
+        vr.body("paths.'/user/username/{username}'.patch.responses", aMapWithSize(2));
+        vr.body("paths.'/user/username/{username}'.patch.responses.'200'.description",
                 equalTo("Password was changed successfully"));
-        vr.body("paths.'/user/{username}'.patch.responses.'400'.description", equalTo("Invalid request"));
+        vr.body("paths.'/user/username/{username}'.patch.responses.'400'.description", equalTo("Invalid request"));
     }
 
     @Test(dataProvider = "formatProvider")
@@ -318,10 +322,11 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/bookings/{id}'.get.responses.'200'.description", equalTo("Booking retrieved"));
         vr.body("paths.'/bookings/{id}'.get.responses.'404'.description", equalTo("Booking not found"));
 
-        vr.body("paths.'/user/{username}'.put.responses", aMapWithSize(3));
-        vr.body("paths.'/user/{username}'.put.responses.'200'.description", equalTo("User updated successfully"));
-        vr.body("paths.'/user/{username}'.put.responses.'400'.description", equalTo("Invalid user supplied"));
-        vr.body("paths.'/user/{username}'.put.responses.'404'.description", equalTo("User not found"));
+        vr.body("paths.'/user/username/{username}'.put.responses", aMapWithSize(3));
+        vr.body("paths.'/user/username/{username}'.put.responses.'200'.description",
+                equalTo("User updated successfully"));
+        vr.body("paths.'/user/username/{username}'.put.responses.'400'.description", equalTo("Invalid user supplied"));
+        vr.body("paths.'/user/username/{username}'.put.responses.'404'.description", equalTo("User not found"));
 
         // @APIResponses on body combined with annotations on method
         vr.body("paths.'/reviews/users/{user}'.get.responses", aMapWithSize(4));
@@ -428,9 +433,10 @@ public class AirlinesAppTest extends AppTestBase {
     public void testExplode(String type) {
         ValidatableResponse vr = callEndpoint(type);
         String explode =
-                "paths.'/user/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.explode";
+                "paths.'/user/username/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.explode";
         vr.body(explode, equalTo(true));
-        explode = "paths.'/user/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.explode";
+        explode =
+                "paths.'/user/username/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.explode";
         vr.body(explode, equalTo(true));
     }
 
@@ -488,7 +494,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(endpoint + ".content", notNullValue());
         vr.body(endpoint + ".required", equalTo(true));
 
-        endpoint = "paths.'/user/{username}'.put.requestBody";
+        endpoint = "paths.'/user/username/{username}'.put.requestBody";
         vr.body(endpoint + ".description", equalTo("Record of a new user to be created in the system."));
         vr.body(endpoint + ".content", notNullValue());
 
@@ -537,7 +543,7 @@ public class AirlinesAppTest extends AppTestBase {
                         hasEntry(equalTo("testScheme2"), empty())),
                 anEmptyMap()));
 
-        vr.body("paths.'/user/{username}'.patch.security", contains(
+        vr.body("paths.'/user/username/{username}'.patch.security", contains(
                 allOf(aMapWithSize(2),
                         hasEntry(equalTo("userApiKey"), empty()),
                         hasEntry(equalTo("userBearerHttp"), empty()))));
@@ -642,13 +648,14 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testEncodingResponses(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        String s = "paths.'/user/{username}'.put.responses.'200'.content.'application/json'.encoding.password.";
+        String s =
+                "paths.'/user/username/{username}'.put.responses.'200'.content.'application/json'.encoding.password.";
         vr.body(s + "contentType", equalTo("text/plain"));
         vr.body(s + "style", equalTo("form"));
         vr.body(s + "explode", equalTo(true));
         vr.body(s + "allowReserved", equalTo(true));
 
-        String t = "paths.'/user/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.";
+        String t = "paths.'/user/username/{username}'.put.responses.'200'.content.'application/xml'.encoding.password.";
         vr.body(t + "contentType", equalTo("text/plain"));
         vr.body(t + "style", equalTo("form"));
         vr.body(t + "explode", equalTo(true));
@@ -658,12 +665,12 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testLink(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        String s = "paths.'/user/{id}'.get.responses.'200'.links.'User name'.";
+        String s = "paths.'/user/id/{id}'.get.responses.'200'.links.'User name'.";
         vr.body(s + "operationId", equalTo("getUserByName"));
         vr.body(s + "description", equalTo("The username corresponding to provided user id"));
         vr.body(s + "x-link", equalTo("test-link"));
 
-        String t = "paths.'/user/{id}'.get.responses.'200'.links.Review.";
+        String t = "paths.'/user/id/{id}'.get.responses.'200'.links.Review.";
         vr.body(t + "operationRef", equalTo("/db/reviews/{userName}"));
         vr.body(t + "description", equalTo("The reviews provided by user"));
 
@@ -675,10 +682,10 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testLinkParameter(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        String s = "paths.'/user/{id}'.get.responses.'200'.links.'User name'.";
+        String s = "paths.'/user/id/{id}'.get.responses.'200'.links.'User name'.";
         vr.body(s + "parameters.userId", equalTo("$request.path.id"));
 
-        String t = "paths.'/user/{id}'.get.responses.'200'.links.Review.";
+        String t = "paths.'/user/id/{id}'.get.responses.'200'.links.Review.";
         vr.body(t + "parameters.'path.userName'", equalTo("$response.body#userName"));
 
         String k = "paths.'/reviews'.post.responses.'201'.links.Review.";
@@ -800,10 +807,10 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body("paths.'/user'.post.tags", containsInAnyOrder("user", "create"));
         vr.body("paths.'/user/createWithArray'.post.tags", containsInAnyOrder("user", "create"));
         vr.body("paths.'/user/createWithList'.post.tags", containsInAnyOrder("user", "create"));
-        vr.body("paths.'/user/{username}'.get.tags", containsInAnyOrder("user"));
-        vr.body("paths.'/user/{username}'.put.tags", containsInAnyOrder("user"));
-        vr.body("paths.'/user/{username}'.delete.tags", containsInAnyOrder("user"));
-        vr.body("paths.'/user/{id}'.get.tags", containsInAnyOrder("user"));
+        vr.body("paths.'/user/username/{username}'.get.tags", containsInAnyOrder("user"));
+        vr.body("paths.'/user/username/{username}'.put.tags", containsInAnyOrder("user"));
+        vr.body("paths.'/user/username/{username}'.delete.tags", containsInAnyOrder("user"));
+        vr.body("paths.'/user/id/{id}'.get.tags", containsInAnyOrder("user"));
         // empty tag was defined
         vr.body("paths.'/user/login'.get.tags", not(hasSize(greaterThan(0))));
         // no tag was defined
@@ -895,7 +902,7 @@ public class AirlinesAppTest extends AppTestBase {
 
         // Reference to Header within Encoding
         String encodingRefHeader =
-                "paths.'/user/{username}'.put.responses.'200'.content.'application/json'.encoding.password.headers.Max-Rate";
+                "paths.'/user/username/{username}'.put.responses.'200'.content.'application/json'.encoding.password.headers.Max-Rate";
         vr.body(encodingRefHeader, notNullValue());
         vr.body(encodingRefHeader + ".$ref", equalTo("#/components/headers/Max-Rate"));
     }
@@ -923,7 +930,7 @@ public class AirlinesAppTest extends AppTestBase {
         vr.body(content1 + ".schema.items", notNullValue());
         vr.body(content1 + ".x-content", equalTo("test-content"));
 
-        String content2 = "paths.'/user/{username}'.put.responses.'200'.content";
+        String content2 = "paths.'/user/username/{username}'.put.responses.'200'.content";
         vr.body(content2, notNullValue());
         vr.body(content2 + ".'application/json'", notNullValue());
         vr.body(content2 + ".'application/json'.schema.$ref", equalTo("#/components/schemas/User"));
@@ -1044,10 +1051,10 @@ public class AirlinesAppTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testExceptionMappers(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        vr.body("paths.'/user/{id}'.get.responses.'404'.description", equalTo("Not Found"));
-        vr.body("paths.'/user/{username}'.get.responses.'404'.description", equalTo("Not Found"));
+        vr.body("paths.'/user/id/{id}'.get.responses.'404'.description", equalTo("Not Found"));
+        vr.body("paths.'/user/username/{username}'.get.responses.'404'.description", equalTo("Not Found"));
 
-        vr.body("paths.'/user/{id}'.get.responses.'404'.content.'application/json'.schema", notNullValue());
+        vr.body("paths.'/user/id/{id}'.get.responses.'404'.content.'application/json'.schema", notNullValue());
 
         vr.body("paths.'/reviews'.post.responses.'400'.description", equalTo("The review was rejected"));
         vr.body("paths.'/reviews'.post.responses.'400'.content.'application/json'.schema", notNullValue());

--- a/tck/src/main/java/org/eclipse/microprofile/openapi/tck/FilterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/tck/FilterTest.java
@@ -139,7 +139,7 @@ public class FilterTest extends AppTestBase {
     @Test(dataProvider = "formatProvider")
     public void testFilterLink(String type) {
         ValidatableResponse vr = callEndpoint(type);
-        String s = "paths.'/user/{id}'.get.responses.'200'.links.'User name'.";
+        String s = "paths.'/user/id/{id}'.get.responses.'200'.links.'User name'.";
         vr.body(s + "operationId", equalTo("getUserByName"));
         vr.body(s + "description", equalTo("filterLink - The username corresponding to provided user id"));
     }


### PR DESCRIPTION
In the original version, the testing apps cannot deploy, as the paths '/user/{username}' and '/user/{id}' are ambiguous.

Updating to version `3.1.1.payara-p1` as the OSGi maven test (`mvn verify`) doesn't allow anything lower than `3.1.1`:
```
[INFO] --- bnd-baseline-maven-plugin:5.2.0:baseline (baseline) @ microprofile-openapi-api ---
[INFO] Determining the baseline version for org.eclipse.microprofile.openapi:microprofile-openapi-api:jar:(,3.1.0.payara-p1) using repositories [central (https://repo.maven.apache.org/maven2, default, releases)]
[INFO] The baseline version was found to be 3.1
[ERROR] The bundle version change (3.1.0 to 3.1.0) is too low, the new version must be at least 3.1.1
```