### PR TITLE
FISH-7118 Correct Version to Follow Patch Process, 2

### DIFF
--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -38,5 +38,8 @@
         </dependency>
     </dependencies>
 
-    
+    <properties>
+        <bnd.baseline.continue.on.error>true</bnd.baseline.continue.on.error>
+    </properties>
+
 </project>


### PR DESCRIPTION
Project `spi` was failing from the same reason as `api` before, applying the same fix.